### PR TITLE
Make sure gh-pages branch gets built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ script: ./script/cibuild
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+branches:
+  only:
+    - gh-pages


### PR DESCRIPTION
This branch is hard-coded in Travis to be ignored unless explicitly
whitelisted.

https://docs.travis-ci.com/user/customizing-the-build/#Whitelisting-or-blacklisting-branches
