### PR TITLE
add missing <li> tag in navigation list

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
   <li>Technical details:</li>
   <li>
       <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
+        <li><a href="technical.html">CSV and JSON</a></li>
         <li><a href="data_structure.html">Data structure</a></li>
         <li><a href="repo_structure.html">Getting most recent data</a></li>
         <li><a href="use_the_data.html">Using the data</a></li>


### PR DESCRIPTION
Spotted our markup was missing an initial `<li>` in the navigation. This fixes it.
