### PR TITLE
Don't boot Jekyll if there are Gemfile.lock changes

### DIFF
--- a/_plugins/gemfile_lock_check.rb
+++ b/_plugins/gemfile_lock_check.rb
@@ -1,0 +1,9 @@
+if `git status -s`.include?('Gemfile.lock')
+  abort <<-COMMIT_CHANGES
+  #################################################
+  #                                               #
+  #   Please commit the changes to Gemfile.lock   #
+  #                                               #
+  #################################################
+  COMMIT_CHANGES
+end


### PR DESCRIPTION
We track the latest version of the `github-pages` gem so that we can be
sure that we're running against the same version as GitHub are using.
However this sometimes causes the tests to fail if you've updated
github-pages locally but not committed the resulting `Gemfile.lock`.

This change will refuse to boot up jekyll if it notices that you have
uncommitted changes to `Gemfile.lock`.
