### PR TITLE
Upgrade html-proofer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     html-pipeline (2.4.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (2.6.1)
+    html-proofer (3.0.6)
       activesupport (~> 4.2)
       addressable (~> 2.3)
       colored (~> 1.2)
@@ -117,7 +117,7 @@ GEM
       pkg-config (~> 1.1.7)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    parallel (1.6.1)
+    parallel (1.9.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     pkg-config (1.1.7)
@@ -140,7 +140,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.1)
-    yell (2.0.5)
+    yell (2.0.6)
 
 PLATFORMS
   ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 require 'bundler/setup'
-require 'html/proofer'
+require 'html-proofer'
 
 desc 'Test the Jekyll site with html-proofer'
 task :test do
   sh 'bundle exec jekyll build'
-  HTML::Proofer.new('./_site').run
+  HTMLProofer.check_directory('./_site').run
 end
 
 task default: :test


### PR DESCRIPTION
Upgrade to the latest version of [html-proofer](https://github.com/gjtorikian/html-proofer). The binary was renamed from `htmlproof` to `htmlproofer` in [v3.0.0](https://github.com/gjtorikian/html-proofer/releases/tag/v3.0.0).
