### PR TITLE
Run html-proofer with rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
 - 2.0.0
 - 2.1.7
 - 2.2.3
-script: ./script/cibuild
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']
 gem 'html-proofer'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       forwardable-extended (~> 2.6)
     pkg-config (1.1.7)
     public_suffix (1.5.3)
+    rake (11.2.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -148,6 +149,7 @@ DEPENDENCIES
   github-pages (= 96)
   html-proofer
   json
+  rake
 
 BUNDLED WITH
    1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'bundler/setup'
+require 'html/proofer'
+
+desc 'Test the Jekyll site with html-proofer'
+task :test do
+  sh 'bundle exec jekyll build'
+  HTML::Proofer.new('./_site').run
+end
+
+task default: :test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-bundle exec htmlproof ./_site


### PR DESCRIPTION
This gives us more control over how html-proofer is run and allows us to potentially configure things like timeouts when checking external links. It also has the added bonus of being potentially easier to understand and change for people familiar with Ruby.
