### PR TITLE
Add timeout for external link checker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'html-proofer'
 desc 'Test the Jekyll site with html-proofer'
 task :test do
   sh 'bundle exec jekyll build'
-  HTMLProofer.check_directory('./_site').run
+  HTMLProofer.check_directory('./_site', typhoeus: { timeout: 30 }).run
 end
 
 task default: :test


### PR DESCRIPTION
This adds a 30 second timeout to html-proofer's external link checker.
Previously we had issues where a site was just hanging without returning
a response. This meant that the tests would never finish locally and
they'd timeout and fail on Travis.

By adding a 30 second timeout we can be alerted if any places we link to
are potentially down or very slow.

This should stop problems like cargografias.org being down, which was fixed in #31.
