### PR TITLE
add link to newly-published botblog post about instructions.json metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,20 +22,21 @@ GEM
     ffi (1.9.14)
     forwardable-extended (2.6.0)
     gemoji (2.1.0)
-    github-pages (96)
+    github-pages (97)
       activesupport (= 4.2.7)
       github-pages-health-check (= 1.2.0)
       jekyll (= 3.2.1)
       jekyll-coffeescript (= 1.0.1)
       jekyll-feed (= 0.5.1)
       jekyll-gist (= 1.4.0)
-      jekyll-github-metadata (= 2.0.2)
+      jekyll-github-metadata (= 2.1.0)
       jekyll-mentions (= 1.2.0)
       jekyll-paginate (= 1.1.0)
       jekyll-redirect-from (= 0.11.0)
       jekyll-sass-converter (= 1.3.0)
       jekyll-seo-tag (= 2.0.0)
       jekyll-sitemap (= 0.10.0)
+      jekyll-swiss (= 0.4.0)
       jemoji (= 0.7.0)
       kramdown (= 1.11.1)
       liquid (= 3.0.6)
@@ -78,7 +79,7 @@ GEM
     jekyll-feed (0.5.1)
     jekyll-gist (1.4.0)
       octokit (~> 4.2)
-    jekyll-github-metadata (2.0.2)
+    jekyll-github-metadata (2.1.0)
       jekyll (~> 3.1)
       octokit (~> 4.0)
     jekyll-mentions (1.2.0)
@@ -93,6 +94,7 @@ GEM
     jekyll-seo-tag (2.0.0)
       jekyll (~> 3.1)
     jekyll-sitemap (0.10.0)
+    jekyll-swiss (0.4.0)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     jemoji (0.7.0)
@@ -132,7 +134,7 @@ GEM
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
-    terminal-table (1.7.2)
+    terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
     thread_safe (0.3.5)
     typhoeus (0.8.0)
@@ -146,7 +148,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 96)
+  github-pages (= 97)
   html-proofer
   json
   rake

--- a/bot.html
+++ b/bot.html
@@ -191,5 +191,12 @@ layout: docs
     We needed to import CSVs because people use spreadsheets, and we use the same simple format for more complex imports too.
   </p>
 </li>
+<li>
+  <!-- 2016-10-06 -->
+  <a class="link--epbot" href="https://medium.com/@everypolitician/my-instructions-are-metadata-in-json-40c441441cf0">My instructions are metadata. In JSON.</a>
+  <p>
+    Everything the bot needs to know in order to combine data from different sources is in the file <code>instructions.json</code>.
+  </p>
+</li>
 </ul>
 


### PR DESCRIPTION
Linking to most recent botblog post 

https://medium.com/@everypolitician/my-instructions-are-metadata-in-json-40c441441cf0

(didn't get this in earlier this week because I hadn't noticed my attempt to commit direct to master had been rejected, oof :-O)
