### PR TITLE
Remove reference to Poplus mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,3 @@ which enable citizens to <a href="http://writeit.poplus.org/">send public messag
 
 <p>As data becomes available from more countries, all in the same format,
 more and more tools like this will become possible.</p>
-
-<h2 id="find-out-more">Find out more</h2>
-
-<p>EveryPolitician is a <a href="http://www.poplus.org/">Poplus</a> project. Drop by
-our <a href="https://groups.google.com/forum/#!forum/poplus">friendly mailing list</a>
-to ask questions or just to say hello.</p>


### PR DESCRIPTION
The Poplus mailing list isn't really the best place to discuss
EveryPolitician any more.

(We need to rewrite all of these docs (#43), but small steps…)